### PR TITLE
[WIP] Libsass 3.2.0

### DIFF
--- a/src/php_sass.h
+++ b/src/php_sass.h
@@ -35,7 +35,5 @@ PHP_METHOD(Sass, getStyle);
 PHP_METHOD(Sass, setStyle);
 PHP_METHOD(Sass, getIncludePath);
 PHP_METHOD(Sass, setIncludePath);
-PHP_METHOD(Sass, getImagePath);
-PHP_METHOD(Sass, setImagePath);
 
 #endif

--- a/src/sass.c
+++ b/src/sass.c
@@ -103,7 +103,7 @@ PHP_METHOD(Sass, compile)
 
     // "Hand over the source, buddy!"
     // "Which one, béchamel or arrabbiata?"
-    context->source_string = source;
+    context->source_string = strdup(source);
 
     // Compile it!
     sass_compile(context);

--- a/src/sass.c
+++ b/src/sass.c
@@ -23,7 +23,6 @@ typedef struct sass_object {
     zend_object zo;
     int style;
     char* include_paths;
-    char* image_path;
 } sass_object;
 
 zend_class_entry *sass_ce;
@@ -33,8 +32,6 @@ void sass_free_storage(void *object TSRMLS_DC)
     sass_object *obj = (sass_object *)object;
     if (obj->include_paths != NULL)
         efree(obj->include_paths);
-    if (obj->image_path != NULL)
-        efree(obj->image_path);
 
     zend_hash_destroy(obj->zo.properties);
     FREE_HASHTABLE(obj->zo.properties);
@@ -76,7 +73,6 @@ PHP_METHOD(Sass, __construct)
     sass_object *obj = (sass_object *)zend_object_store_get_object(this TSRMLS_CC);
     obj->style = SASS_STYLE_NESTED;
     obj->include_paths = NULL;
-    obj->image_path = NULL;
 
 }
 
@@ -103,7 +99,6 @@ PHP_METHOD(Sass, compile)
     struct sass_context* context = sass_new_context();
 
     context->options.include_paths = this->include_paths != NULL ? this->include_paths : "";
-    context->options.image_path = this->include_paths != NULL ? this->image_path : "";
     context->options.output_style = this->style;
 
     // "Hand over the source, buddy!"
@@ -169,7 +164,6 @@ PHP_METHOD(Sass, compile_file)
     struct sass_file_context* context = sass_new_file_context();
 
     context->options.include_paths = this->include_paths != NULL ? this->include_paths : "";
-    context->options.image_path = this->include_paths != NULL ? this->image_path : "";
     context->options.output_style = this->style;
 
     context->input_path = file;
@@ -259,38 +253,6 @@ PHP_METHOD(Sass, setIncludePath)
     RETURN_NULL();
 }
 
-PHP_METHOD(Sass, getImagePath)
-{
-    zval *this = getThis();
-
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "", NULL) == FAILURE) {
-        RETURN_FALSE;
-    }
-
-    sass_object *obj = (sass_object *)zend_object_store_get_object(this TSRMLS_CC);
-    if (obj->image_path == NULL) RETURN_STRING("", 1)
-    RETURN_STRING(obj->image_path, 1)
-}
-
-PHP_METHOD(Sass, setImagePath)
-{
-    zval *this = getThis();
-
-    char *path;
-    int path_len;
-
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &path, &path_len) == FAILURE)
-        RETURN_FALSE;
-
-    sass_object *obj = (sass_object *)zend_object_store_get_object(this TSRMLS_CC);
-    if (obj->image_path != NULL)
-        efree(obj->image_path);
-    obj->image_path = estrndup(path, path_len);
-
-    RETURN_NULL();
-}
-
-
 /* --------------------------------------------------------------
  * EXCEPTION HANDLING
  * ------------------------------------------------------------ */
@@ -312,8 +274,6 @@ zend_function_entry sass_methods[] = {
     PHP_ME(Sass,  setStyle,        NULL,  ZEND_ACC_PUBLIC)
     PHP_ME(Sass,  getIncludePath,  NULL,  ZEND_ACC_PUBLIC)
     PHP_ME(Sass,  setIncludePath,  NULL,  ZEND_ACC_PUBLIC)
-    PHP_ME(Sass,  getImagePath,    NULL,  ZEND_ACC_PUBLIC)
-    PHP_ME(Sass,  setImagePath,    NULL,  ZEND_ACC_PUBLIC)
     {NULL, NULL, NULL}
 };
 
@@ -340,7 +300,6 @@ static PHP_MINIT_FUNCTION(sass)
     REGISTER_SASS_CLASS_CONST_LONG(STYLE_EXPANDED, SASS_STYLE_EXPANDED);
     REGISTER_SASS_CLASS_CONST_LONG(STYLE_COMPACT, SASS_STYLE_COMPACT);
     REGISTER_SASS_CLASS_CONST_LONG(STYLE_COMPRESSED, SASS_STYLE_COMPRESSED);
-    REGISTER_SASS_CLASS_CONST_LONG(STYLE_FORMATTED, SASS_OUTPUT_FORMATTED);
 
     REGISTER_STRING_CONSTANT("SASS_FLAVOR", SASS_FLAVOR, CONST_CS | CONST_PERSISTENT);
 

--- a/tests/handles_style.phpt
+++ b/tests/handles_style.phpt
@@ -25,10 +25,6 @@ echo $sass->getStyle();
 $sass->setStyle(Sass::STYLE_COMPRESSED);
 echo $sass->getStyle();
 
-// test SASS_OUTPUT_FORMATTED
-$sass->setStyle(Sass::STYLE_FORMATTED);
-echo $sass->getStyle();
-
 ?>
 --EXPECT--
-001234
+00123

--- a/tests/parse_file_parses_file.phpt
+++ b/tests/parse_file_parses_file.phpt
@@ -13,7 +13,7 @@ echo $css;
 --EXPECT--
 @import url(../blahblah/blah.blah);
 div {
-  blah: "hello 4 world px bloo\n blah"; }
+  blah: "hello 4 world px bloo blah"; }
 
 div {
   blah: "foo iphone"; }

--- a/tests/support/test.scss
+++ b/tests/support/test.scss
@@ -1,7 +1,7 @@
 @import url(../blahblah/blah.blah);
 
 div {
-  blah: "hello #{2+2} world #{unit(23px)} #{'bloo\n'} blah";
+  blah: "hello #{2+2} world #{unit(23px)} #{'bloo'} blah";
 }
 
 $foo: iphone;


### PR DESCRIPTION
An update to libsass 3.2.0.  Currently this is beta, but the initial work has been done to bring the php module up to pay with the library.  Once the official release comes out this should be able to be merged.

Warning! this contains the removal of the image_path.  This is no longer available in libsass: sass/libsass#489

It is also worth mentioning sass/libsass#940.  There is a "breaking" change that was introduced related to memory management.  The general quick fix was to add a strdup() call before passing along the source.  Without this there was a "pointer being freed was not allocated" error.