### PR TITLE
Add support for custom importer and functions

### DIFF
--- a/src/sass.c
+++ b/src/sass.c
@@ -50,8 +50,7 @@ void sass_free_storage(void *object TSRMLS_DC)
     if (obj->map_root != NULL)
         efree(obj->map_root);
 
-    zend_hash_destroy(obj->zo.properties);
-    FREE_HASHTABLE(obj->zo.properties);
+    zend_object_std_dtor(obj);
 
     efree(obj);
 }

--- a/tests/custom_function.phpt
+++ b/tests/custom_function.phpt
@@ -1,0 +1,27 @@
+--TEST--
+custom importer: external file
+--SKIPIF--
+<?php if (!extension_loaded("sass")) print "skip"; ?>
+--FILE--
+<?php
+
+$sass = new Sass();
+$sass->setFunctions([
+    'a($a)' => function($in, $path_info){
+        echo $in;
+        return "hello $in";
+    },
+    'b($a)' => function($in, $path_info){
+        echo $in;
+        return "goodbye $in";
+    },
+]);
+echo $sass->compile('body { content: a("foo"); } h1 { content: b("bar"); }');
+
+?>
+--EXPECT--
+foobarbody {
+  content: hello foo; }
+
+h1 {
+  content: goodbye bar; }

--- a/tests/custom_importer_compiled_output.phpt
+++ b/tests/custom_importer_compiled_output.phpt
@@ -1,0 +1,19 @@
+--TEST--
+custom importer: external file
+--SKIPIF--
+<?php if (!extension_loaded("sass")) print "skip"; ?>
+--FILE--
+<?php
+
+$sass = new Sass();
+$sass->setImporter(function($in){
+    echo "$in\n";
+    return [null, '.foo { color: red;}'];
+});
+echo $sass->compile('@import "flupp";');
+
+?>
+--EXPECT--
+flupp
+.foo {
+  color: red; }

--- a/tests/custom_importer_external_file.phpt
+++ b/tests/custom_importer_external_file.phpt
@@ -1,0 +1,19 @@
+--TEST--
+custom importer: external file
+--SKIPIF--
+<?php if (!extension_loaded("sass")) print "skip"; ?>
+--FILE--
+<?php
+
+$sass = new Sass();
+$sass->setImporter(function($in){
+    echo "$in\n";
+    return [__DIR__.'/support/foo.scss'];
+});
+echo $sass->compile('@import "flupp";');
+
+?>
+--EXPECT--
+flupp
+h2 {
+  color: green; }

--- a/tests/output_path_with_memory_compile.phpt
+++ b/tests/output_path_with_memory_compile.phpt
@@ -1,0 +1,14 @@
+--TEST--
+set output_path when compiling in memory
+--SKIPIF--
+<?php if (!extension_loaded("sass")) print "skip"; ?>
+--FILE--
+<?php
+
+$sass = new Sass();
+echo $sass->compile('@import "subsub/a.scss";', __DIR__.'/support/sub/a.scss');
+
+?>
+--EXPECT--
+body {
+  background: red; }

--- a/tests/support/sub/subsub/a.scss
+++ b/tests/support/sub/subsub/a.scss
@@ -1,0 +1,3 @@
+body {
+    background: red;
+}


### PR DESCRIPTION
This PR will adds support for register custom functions and importers written in PHP to be available during the compilation process.

Importers:

```php
$sass->setImporter(function($in){
    var_dump($in);
    return ($in == 'flupp')
        ? [ [null, '.compiled2 { color: yellow !important }' ],
            [__DIR__.'/otherfile.scss'],
        ]
        : null;
});
```
In your callback, return either an array or an array of arrays. If you set the 0th element, the compiler will instead process the file provided there.

If you set the 1st element, the compiler will use whatever you return there in place of the import.

Return `null` if you want the default processing to happen.

And functions

```php
$sass = new Sass();
$sass->setFunctions([
    'a($a)' => function($in, $path_info){
        return "hello $in";
    },
    'b($a)' => function($in, $path_info){
        return "goodbye $in";
    },
]);

echo $sass->compile('body { content: a("foo"); } h1 { content: b("bar"); }');
```
At this point, the functions API is still very limited and extremely stringy, converting all arguments to a single string and only allowing you to return a string.

But hey - it’s a start.